### PR TITLE
Add square draw command

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from shared.util import check_int, check_color, generate_random_symbols
 from modules.draw.line import draw_line
 from modules.draw.fill import draw_fill
 from modules.draw.square import draw_square
-from modules.types.custom import opacity_type, accent_type
+from modules.types.custom import opacity_type, accent_type, twoone_tuple_int
 
 # --- Argument Parsers
 
@@ -137,6 +137,12 @@ draw_parser.add_argument(
     default=0,
     type=int,
     metavar="Y_POS",
+)
+draw_parser.add_argument(
+    "--border",
+    type=twoone_tuple_int,
+    default=None,
+    help="add a border around the text, --border X,[Y]",
 )
 draw_parser.add_argument(
     "--preview",
@@ -317,6 +323,7 @@ if __name__ == "__main__":
                 args.angle_x_pos,
                 args.angle_y_pos,
                 args.gradient_step,
+                args.border
             )
 
         if args.mode == "fill":
@@ -338,6 +345,7 @@ if __name__ == "__main__":
                 args.y_margin,
                 args.angle,
                 args.gradient_step,
+                args.border
             )
 
         if args.mode == "square":
@@ -355,7 +363,7 @@ if __name__ == "__main__":
                 args.accent,
                 args.x_margin,
                 args.y_margin,
-                args.gradient_step,
+                args.border
             )
 
         image.show()

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from shared.log import log
 from shared.util import check_int, check_color, generate_random_symbols
 from modules.draw.line import draw_line
 from modules.draw.fill import draw_fill
+from modules.draw.square import draw_square
 from modules.types.custom import opacity_type, accent_type
 
 # --- Argument Parsers
@@ -63,7 +64,10 @@ draw_parser = command_subparsers.add_parser(
     "draw", parents=[root_parser], help="generate an image from provided text"
 )
 draw_parser.add_argument(
-    "mode", metavar="MODE", choices=["line", "fill"], help="mode to use: line|fill"
+    "mode",
+    metavar="MODE",
+    choices=["line", "fill", "square"],
+    help="mode to use: line|fill",
 )
 draw_parser.add_argument("text", metavar="TEXT", help="text to draw")
 draw_parser.add_argument(
@@ -267,6 +271,14 @@ if __name__ == "__main__":
         if args.bg_color:
             bg_color = check_color(args.bg_color)
 
+        if args.mode == "square":
+            if args.x_margin == 4:
+                args.x_margin = 0
+            if args.y_margin == -20:
+                args.y_margin = 0
+            if args.accent == -3:
+                args.accent = "all"
+
         print("[bold green]------ USING PARAMS ------[/bold green]")
         print(f"mode:       {args.mode}")
         print(f"resolution: [bold cyan]{width}x{height}[/bold cyan] px")
@@ -325,6 +337,24 @@ if __name__ == "__main__":
                 args.x_margin,
                 args.y_margin,
                 args.angle,
+                args.gradient_step,
+            )
+
+        if args.mode == "square":
+            image = draw_square(
+                width,
+                height,
+                font_file,
+                font_size,
+                args.text,
+                text_color,
+                bg_color,
+                args.x_pos,
+                args.y_pos,
+                args.opacity,
+                args.accent,
+                args.x_margin,
+                args.y_margin,
                 args.gradient_step,
             )
 

--- a/modules/draw/fill.py
+++ b/modules/draw/fill.py
@@ -20,7 +20,8 @@ def draw_fill(
     x_margin: int,
     y_margin: int,
     angle: int,
-    gradient_step
+    gradient_step: float,
+    border: tuple[int,int]
 ):
     RESOLUTION = (width, height)
     FONT = ImageFont.truetype(font_file, font_size)
@@ -102,5 +103,9 @@ def draw_fill(
 
     image.paste(image_FG)
     image = Image.alpha_composite(image_BG, image_FG)
+
+    if border and border[0] != 0:
+        image = image.crop((border[0], border[1], image.width - border[0], image.height - border[1]))
+        image = ImageOps.expand(image, (border[0], border[1]), fill=bg_color)
 
     return image

--- a/modules/draw/line.py
+++ b/modules/draw/line.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageFont, ImageDraw
+from PIL import Image, ImageFont, ImageDraw, ImageOps
 from rich import print
 from shared.util import hex_to_rgb, rgb_to_rgba, crop_center
 
@@ -7,7 +7,8 @@ def draw_line(width: int, height: int,
             text: str, text_color: str, bg_color: str,
             x_offset: int, x_pos: str, y_offset: int, y_pos: int,
             opacity: float, accent: int | str, x_margin: int,
-            angle: int, angle_x_pos: int, angle_y_pos: int, gradient_step: int
+            angle: int, angle_x_pos: int, angle_y_pos: int, gradient_step: int,
+            border: tuple[int,int]
         ):
     RESOLUTION = (width, height)
     FONT = ImageFont.truetype(font_file, font_size)
@@ -70,5 +71,9 @@ def draw_line(width: int, height: int,
 
     image.paste(image_FG, (angle_x_pos, angle_y_pos))
     image_BG.paste(image, mask=image)
+
+    if border and border[0] != 0:
+        image_BG = image_BG.crop((border[0], border[1], image_BG.width - border[0], image_BG.height - border[1]))
+        image_BG = ImageOps.expand(image_BG, (border[0], border[1]), fill=bg_color)
 
     return image_BG

--- a/modules/draw/square.py
+++ b/modules/draw/square.py
@@ -1,0 +1,109 @@
+from PIL import Image, ImageFont, ImageDraw, ImageEnhance
+from shared.util import hex_to_rgb
+from shared.log import log
+from sys import exit
+
+def draw_square(
+    width: int,
+    height: int,
+    font_file: str,
+    font_size: int,
+    text: str,
+    text_color: str,
+    bg_color: str,
+    x_pos: str,
+    y_pos: int,
+    opacity: float,
+    accent: int | str,
+    x_margin: int,
+    y_margin: int,
+    gradient_step: int,
+):
+    RESOLUTION = (width, height)
+    FONT = ImageFont.truetype(font_file, font_size)
+
+    image = Image.new("RGBA", RESOLUTION, (0, 0, 0, 0))
+    image_BG = Image.new("RGBA", RESOLUTION, bg_color)
+    image_FG = Image.new("RGBA", RESOLUTION, (0, 0, 0, 0))
+
+    image_FG_draw = ImageDraw.Draw(image_FG)
+    image_FG_draw.font = FONT
+    image_FG_draw.fontmode = "L"
+
+    text_box = image_FG_draw.textbbox((0, 0), text)
+
+    if x_pos < 0:
+        x_pos = width + x_pos
+    render_x_pos = x_pos + x_margin
+
+    if y_pos < 0:
+        y_pos = height + y_pos
+    render_y_pos = y_pos + x_margin
+
+    col = hex_to_rgb(text_color)
+
+    image_TEXT = Image.new(
+        "RGBA", (text_box[2], text_box[3] - text_box[1]), (0, 0, 0, 0)
+    )
+    image_TEXT_draw = ImageDraw.Draw(image_TEXT)
+    image_TEXT_draw.font = FONT
+    image_TEXT_draw.fontmode = "L"
+    image_TEXT_draw.text((0, -text_box[1]), text, col)
+
+    image_TEXT_90 = image_TEXT.rotate(90, resample=Image.BICUBIC, expand=True)
+    image_TEXT_180 = image_TEXT.rotate(180, resample=Image.BICUBIC, expand=True)
+    image_TEXT_270 = image_TEXT.rotate(270, resample=Image.BICUBIC, expand=True)
+
+    image_TEXT_Combine = Image.new(
+        "RGBA",
+        (image_TEXT.width, (image_TEXT_90.height + (image_TEXT.height * 2))),
+        (0, 0, 0, 0),
+    )
+    image_TEXT_Combine.paste(image_TEXT, (0, 0))
+    image_TEXT_Combine.paste(image_TEXT_90, (0, image_TEXT.height))
+    image_TEXT_Combine.paste(
+        image_TEXT_180, (0, image_TEXT.height + image_TEXT_90.height)
+    )
+    image_TEXT_Combine.paste(
+        image_TEXT_270,
+        (image_TEXT_Combine.width - image_TEXT_270.width, image_TEXT.height),
+    )
+
+    total_x_lines = (image_FG.width // image_TEXT_Combine.width) + 1
+    total_y_lines = (image_FG.height // image_TEXT_Combine.height) + 1
+
+    accent_x = 0
+    accent_y = 0
+
+    if accent == "gradient":
+        log.error("Gradient accent is not supported for this mode")
+        exit(1)
+
+    if accent not in ["off", "all"]:
+        accent_x = accent
+        accent_y = accent // 2
+        if accent < 0:
+            accent_x = total_x_lines + accent
+            accent_y = total_y_lines + (accent // 2)
+
+    for y in range(total_y_lines):
+        for x in range(total_x_lines):
+            TEXT_LAYER_COPY = image_TEXT_Combine.copy()
+
+            if y != (accent_y - 1) and x != (accent_x - 1):
+                if accent == "all":
+                    opacity = 1
+
+                alpha = TEXT_LAYER_COPY.split()[3]
+                alpha = ImageEnhance.Brightness(alpha).enhance(opacity)
+                TEXT_LAYER_COPY.putalpha(alpha)
+
+            image_FG.paste(TEXT_LAYER_COPY, (render_x_pos, render_y_pos))
+            render_x_pos += image_TEXT_Combine.width + x_margin
+        render_x_pos = x_margin
+        render_y_pos += image_TEXT_Combine.height + y_margin
+
+    image.paste(image_FG, (0, 0))
+    image_BG.paste(image, mask=image)
+
+    return image_BG

--- a/modules/draw/square.py
+++ b/modules/draw/square.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageFont, ImageDraw, ImageEnhance
+from PIL import Image, ImageFont, ImageDraw, ImageEnhance, ImageOps
 from shared.util import hex_to_rgb
 from shared.log import log
 from sys import exit
@@ -17,7 +17,7 @@ def draw_square(
     accent: int | str,
     x_margin: int,
     y_margin: int,
-    gradient_step: int,
+    border: tuple[int,int]
 ):
     RESOLUTION = (width, height)
     FONT = ImageFont.truetype(font_file, font_size)
@@ -105,5 +105,9 @@ def draw_square(
 
     image.paste(image_FG, (0, 0))
     image_BG.paste(image, mask=image)
+
+    if border and border[0] != 0:
+        image_BG = image_BG.crop((border[0], border[1], image_BG.width - border[0], image_BG.height - border[1]))
+        image_BG = ImageOps.expand(image_BG, (border[0], border[1]), fill=bg_color)
 
     return image_BG

--- a/modules/types/custom.py
+++ b/modules/types/custom.py
@@ -22,3 +22,15 @@ def accent_type(s: str) -> int | Literal["off"] |  Literal["all"] |  Literal["gr
         return value
     except TypeError as e:
         raise argparse.ArgumentTypeError(f"{s!r} should be one of number|off|all|gradient") from e
+
+
+def twoone_tuple_int(s: str) -> tuple[int,int]:
+    int1 = 0
+    int2 = 0
+    ints = s.split(",")
+    int1 = int(ints[0])
+    if len(ints) < 2 or ints[1] == "":
+        int2 = int1
+    else:
+        int2 = int(ints[1])
+    return int1, int2


### PR DESCRIPTION
## Summary by Sourcery

Enable drawing text in a square pattern by adding a new CLI mode and reusable border handling across all draw modes

New Features:
- Add a new 'square' mode to the draw command for arranging text in a square layout
- Introduce a --border option to crop and expand image borders around rendered text

Enhancements:
- Extend line and fill drawing functions to support border cropping and expansion
- Add a twoone_tuple_int argparse type for parsing two-value tuple arguments
- Apply square-mode specific default adjustments for margins and accents